### PR TITLE
Allow functions to take arguments

### DIFF
--- a/mdmm/mdmm.py
+++ b/mdmm/mdmm.py
@@ -36,6 +36,8 @@ class Constraint(nn.Module, metaclass=abc.ABCMeta):
     def forward(self, x=None):
         if x is None:
             fn_value = self.fn()
+        elif type(x) in [list, tuple]:
+            fn_value = self.fn(*x)
         else:
             fn_value = self.fn(x)    
         inf = self.infeasibility(fn_value)
@@ -162,12 +164,7 @@ class MDMM(nn.ModuleList):
         if len(arg_list) == 0:
             arg_list = [None]*len(self)
         for c, arg in zip(self, arg_list):
-            if arg is None:
-                c_return = c()
-            elif type(arg) in [list, tuple]:
-                c_return = c(*arg)
-            else:
-                c_return = c(arg)
+            c_return = c(arg)
             value += c_return.value
             fn_values.append(c_return.fn_value)
             infs.append(c_return.inf)


### PR DESCRIPTION
Small generalization of your code to allow the functions to which constraints are applied to be able to take arguments. This allows for using multiple loss functions, constraining a model's output to be within a certain range, etc, etc.
As a proof of concept, you can append the following to the constraints in the MNIST example to constrain the output to sum to 50:
`constraints.append(EqConstraint(torch.sum, 50, scale=scale, damping=damping))`
and then change the mdmm_module call to:
`mdmm_return = mdmm_module(loss, [None, None, None, outputs])`
The first 3 Nones are for the three constraints that take no argument, while the last constraint we added will take `outputs`. That's all that's needed to make it work.
The change is backward compatible and no list is required if no constraint functions need arguments. Also functions that require multiple arguments, like a secondary loss, can have their arguments provided as a tuple or list within the argument list.